### PR TITLE
Add release script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog][] and this project adheres to
 ### Added
 
 * Add a CHANGELOG ([#3][])
+* Add release script ([#4][])
 
 ### Changed
 
@@ -26,6 +27,7 @@ The format is based on [Keep a Changelog][] and this project adheres to
 
 [Unreleased]: https://github.com/jonallured/tinysky/compare/v0.0.1...HEAD
 [#3]: https://github.com/jonallured/tinysky/pull/3
+[#4]: https://github.com/jonallured/tinysky/pull/4
 
 ## [0.0.1][] - 2024-08-11
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "bump"
 gem "rake"
 gem "rspec"
 gem "standard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
   specs:
     ast (2.4.2)
     base64 (0.2.0)
+    bump (0.10.0)
     diff-lcs (1.5.1)
     faraday (2.10.1)
       faraday-net_http (>= 2.0, < 3.2)
@@ -84,6 +85,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bump
   rake
   rspec
   standard

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,6 @@
+#! /bin/sh
+set -ex
+
+bump patch --tag
+git push origin main
+git push origin --tags


### PR DESCRIPTION
This PR adds a very basic attempt at a release script. I discovered a gem called `bump` that's a really nice way to ensure the version number is bumped correctly so I'm trying that out on this project.