### PR TITLE
Update Ruby matrix for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,9 @@ name: Ruby
 
 on:
   push:
-    branches:
-      - main
-
+    branches: ["main"]
   pull_request:
+    branches: ["main"]
 
 jobs:
   build:
@@ -14,16 +13,14 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.1.6'
-          - '3.2.5'
-          - '3.3.5'
+          - '3.4'
+          - '3.3'
+          - '3.2'
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Run the default task
-      run: bundle exec rake
+        ruby-version: ${{ matrix.ruby }}
+    - run: bundle exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog][] and this project adheres to
 
 ### Changed
 
+* Update Ruby matrix for CI ([#11][])
+
 ### Deprecated
 
 ### Removed
@@ -58,3 +60,4 @@ The format is based on [Keep a Changelog][] and this project adheres to
 [#5]: https://github.com/jonallured/tinysky/pull/5
 [#6]: https://github.com/jonallured/tinysky/pull/6
 [#7]: https://github.com/jonallured/tinysky/pull/7
+[#11]: https://github.com/jonallured/tinysky/pull/11

--- a/tinysky.gemspec
+++ b/tinysky.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description = "A tiny client gem for the Bluesky API that focuses on creating posts."
   spec.homepage = "https://github.com/jonallured/tinysky"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 3.2"
 
   spec.metadata["homepage_uri"] = spec.homepage
 


### PR DESCRIPTION
There are actually a few things here:

* update the Ruby matrix to drop 3.1 and add 3.4
* apply some GitHub action patterns I use elsewhere
* update gem spec to require at least Ruby 3.2

This should unblock #10.