### PR TITLE
Improve CI configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Ruby
+name: Main
 
 on:
   push:
@@ -7,20 +7,22 @@ on:
     branches: ["main"]
 
 jobs:
-  build:
+  test:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby:
-          - '4.0'
-          - '3.4'
-          - '3.3'
-
+        include:
+          - name: "ruby-latest"
+            ruby-version: "4.0"
+          - name: "ruby-minus-one"
+            ruby-version: "3.4"
+          - name: "ruby-minus-two"
+            ruby-version: "3.3"
     steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@v1
-      with:
-        bundler-cache: true
-        ruby-version: ${{ matrix.ruby }}
-    - run: bundle exec rake
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ${{ matrix.ruby-version }}
+      - run: bundle exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog][] and this project adheres to
 * Use Zeitwerk for loading ([#10][])
 * Update Ruby matrix for CI ([#11][])
 * Upgrade to Ruby 4 ([#12][])
+* Improve CI configuration ([#13][])
 
 ### Deprecated
 
@@ -65,3 +66,4 @@ The format is based on [Keep a Changelog][] and this project adheres to
 [#10]: https://github.com/jonallured/tinysky/pull/10
 [#11]: https://github.com/jonallured/tinysky/pull/11
 [#12]: https://github.com/jonallured/tinysky/pull/12
+[#13]: https://github.com/jonallured/tinysky/pull/13

--- a/README.md
+++ b/README.md
@@ -43,5 +43,5 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/jonall
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
 
-[actions]: https://github.com/jonallured/tinysky/actions
+[actions]: https://github.com/jonallured/tinysky/actions/workflows/main.yml
 [badge]: https://github.com/jonallured/tinysky/actions/workflows/main.yml/badge.svg


### PR DESCRIPTION
This PR is mostly about using general names for the 3 Ruby versions in the matrix so that as they change I don't have to update my repo settings. This allows the settings to enforce that these jobs pass but does not tie them to a specific Ruby version number. There are some other odds and ends but that's the headline.