### PR TITLE
Add support for record embeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog][] and this project adheres to
 
 * Add update script ([#7][])
 * Add support for link facets ([#15][])
+* Add support for record embeds ([#16][])
 
 ### Changed
 
@@ -71,3 +72,4 @@ The format is based on [Keep a Changelog][] and this project adheres to
 [#13]: https://github.com/jonallured/tinysky/pull/13
 [#14]: https://github.com/jonallured/tinysky/pull/14
 [#15]: https://github.com/jonallured/tinysky/pull/15
+[#16]: https://github.com/jonallured/tinysky/pull/16

--- a/examples/create_record_with_embed.rb
+++ b/examples/create_record_with_embed.rb
@@ -1,0 +1,37 @@
+require "bundler/setup"
+require "tinysky"
+
+BlogPost = Struct.new(:url, :title, :description, :image_url)
+
+blog_post = BlogPost.new(
+  "https://www.jonallured.com/posts/2026/02/14/upgrading-to-ruby-four-oh.html",
+  "Upgrading to Ruby 4.0",
+  "Ruby 4.0 was released a couple months ago on Christmas and I had been meaning to upgrade for a while. I noticed that version 4.0.1 came out too so that's always a good sign that things are stable and ready for prime time.",
+  "https://www.jonallured.com/images/post-95/social-share.png"
+)
+
+credentials_path = "/Users/jon/Desktop/tinysky_credentials.json"
+credentials = JSON.load_file(credentials_path, symbolize_names: true)
+client = Tinysky::Client.new(credentials)
+
+blob_data = Faraday.get(blog_post.image_url).body
+content_type = "image/png"
+upload_response = client.upload_blob(blob_data, content_type)
+thumb = upload_response.body["blob"]
+
+embed = Tinysky::ExternalEmbed.new(
+  description: blog_post.description,
+  thumb: thumb,
+  title: blog_post.title,
+  uri: blog_post.url
+)
+
+message = "New blog post: https://www.jonallured.com/posts/2026/02/14/upgrading-to-ruby-four-oh.html"
+facets = Tinysky::FacetParser.for(message)
+
+record_options = {
+  embed: embed,
+  facets: facets
+}
+
+client.create_record(message, record_options)

--- a/lib/tinysky/client.rb
+++ b/lib/tinysky/client.rb
@@ -43,6 +43,18 @@ module Tinysky
       @connection.post(path, body, headers)
     end
 
+    def upload_blob(blob_data, content_type)
+      create_session if expired_token?
+
+      headers = {
+        "Authorization" => "Bearer #{@access_jwt}",
+        "Content-Type" => content_type
+      }
+
+      path = Tinysky::Endpoints::REPO_UPLOAD_BLOB
+      @connection.post(path, blob_data, headers)
+    end
+
     private
 
     def expired_token?

--- a/lib/tinysky/endpoints.rb
+++ b/lib/tinysky/endpoints.rb
@@ -1,6 +1,7 @@
 module Tinysky
   module Endpoints
     REPO_CREATE_RECORD = "/xrpc/com.atproto.repo.createRecord"
+    REPO_UPLOAD_BLOB = "/xrpc/com.atproto.repo.uploadBlob"
     SERVER_CREATE_SESSION = "/xrpc/com.atproto.server.createSession"
   end
 end

--- a/lib/tinysky/external_embed.rb
+++ b/lib/tinysky/external_embed.rb
@@ -1,0 +1,22 @@
+module Tinysky
+  class ExternalEmbed
+    def initialize(attrs)
+      @description = attrs[:description]
+      @thumb = attrs[:thumb]
+      @title = attrs[:title]
+      @uri = attrs[:uri]
+    end
+
+    def to_hash
+      {
+        "$type" => Tinysky::Lexicon::EXTERNAL_EMBED,
+        "external" => {
+          "description" => @description,
+          "thumb" => @thumb,
+          "title" => @title,
+          "uri" => @uri
+        }
+      }
+    end
+  end
+end

--- a/lib/tinysky/feed_post.rb
+++ b/lib/tinysky/feed_post.rb
@@ -13,6 +13,7 @@ module Tinysky
         "text" => @text
       }
 
+      hsh["embed"] = embed.to_hash unless embed.nil?
       hsh["facets"] = facets.map(&:to_hash) if facets.any?
 
       hsh
@@ -23,6 +24,10 @@ module Tinysky
     def created_at
       as_of = @options[:as_of] || DateTime.now
       as_of.iso8601
+    end
+
+    def embed
+      @options[:embed]
     end
 
     def facets

--- a/lib/tinysky/lexicon.rb
+++ b/lib/tinysky/lexicon.rb
@@ -1,5 +1,6 @@
 module Tinysky
   module Lexicon
+    EXTERNAL_EMBED = "app.bsky.embed.external"
     FEED_POST = "app.bsky.feed.post"
     LINK_FACET = "app.bsky.richtext.facet#link"
   end

--- a/spec/lib/tinysky/feed_post_spec.rb
+++ b/spec/lib/tinysky/feed_post_spec.rb
@@ -17,6 +17,45 @@ describe Tinysky::FeedPost do
       end
     end
 
+    context "with nil embed" do
+      it "ignores the embed option" do
+        text = "hello world!"
+        embed = nil
+        options = {embed: embed}
+        feed_post = Tinysky::FeedPost.new(text, options)
+        expect(feed_post.to_hash.keys).to eq(
+          ["$type", "createdAt", "langs", "text"]
+        )
+      end
+    end
+
+    context "with an embed" do
+      it "returns a shape with that embed" do
+        text = "hello world!"
+        as_of = DateTime.now
+        embed = Tinysky::ExternalEmbed.new({})
+        options = {as_of: as_of, embed: embed}
+        feed_post = Tinysky::FeedPost.new(text, options)
+        expect(feed_post.to_hash).to eq(
+          {
+            "$type" => Tinysky::Lexicon::FEED_POST,
+            "createdAt" => as_of.iso8601,
+            "embed" => {
+              "$type" => Tinysky::Lexicon::EXTERNAL_EMBED,
+              "external" => {
+                "description" => nil,
+                "thumb" => nil,
+                "title" => nil,
+                "uri" => nil
+              }
+            },
+            "langs" => ["en-US"],
+            "text" => "hello world!"
+          }
+        )
+      end
+    end
+
     context "with nil facets" do
       it "ignores the facets option" do
         text = "hello world!"


### PR DESCRIPTION
This PR adds support for records with an embed. It adds a method to the client that can upload a blob and then I added another example script that uses this plus the `ExternalEmbed` class to construct a record with an embed.