### PR TITLE
Move to automated release on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
           - name: "ruby-minus-two"
             ruby-version: "3.3"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  test:
+    name: ruby-latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: "4.0"
+      - run: bundle exec rake
+  push:
+    name: Push gem to RubyGems.org
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: "4.0"
+      - uses: rubygems/release-gem@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog][] and this project adheres to
 * Upgrade to Ruby 4 ([#12][])
 * Improve CI configuration ([#13][])
 * Extract modules for api details ([#14][])
+* Move to automated release on CI ([#17][])
 
 ### Deprecated
 
@@ -73,3 +74,4 @@ The format is based on [Keep a Changelog][] and this project adheres to
 [#14]: https://github.com/jonallured/tinysky/pull/14
 [#15]: https://github.com/jonallured/tinysky/pull/15
 [#16]: https://github.com/jonallured/tinysky/pull/16
+[#17]: https://github.com/jonallured/tinysky/pull/17

--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+## Releasing
+
+The release process is automated but should start with a commit to update the
+CHANGELOG. This commit should add the new version and then update the Unreleased
+section back to defaults. It should also update the links. Once that's done then
+the actual process can be kicked off like so:
+
+```
+$ bin/release
+```
+
+Which will create a commit that bumps the patch version, push the commit to
+GitHub and then push the tag that triggers the release.yml workflow. That
+workflow will run tests and then push to RubyGems.org.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/jonallured/tinysky.

--- a/bin/release
+++ b/bin/release
@@ -2,7 +2,5 @@
 set -ex
 
 bump patch --tag
-gem build --output tinysky.gem
-gem push tinysky.gem
 git push origin main
 git push origin --tags


### PR DESCRIPTION
I discovered that RubyGems.org supports something called [Trusted Publishing](https://guides.rubygems.org/trusted-publishing/) and so this PR moves to automated releases with this strategy. Once I setup the publisher on RubyGems.org then I grabbed the official publishing action from here: https://github.com/rubygems/release-gem and then just did a little customization. I updated it to run tests before pushing and then configured it to run on tag pushes.

I also updated the README to reflect this change and I'll verify that it works by running a release once this all lands.