### PR TITLE
Upgrade JWT dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     tinysky (0.0.4)
       faraday (~> 2)
-      jwt (~> 2)
+      jwt
       zeitwerk
 
 GEM
@@ -14,7 +14,7 @@ GEM
     bump (0.10.0)
     date (3.5.1)
     diff-lcs (1.6.2)
-    erb (6.0.1)
+    erb (6.0.2)
     faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -28,7 +28,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.18.1)
-    jwt (2.10.2)
+    jwt (3.1.2)
       base64
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
@@ -65,7 +65,7 @@ GEM
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.7)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)

--- a/tinysky.gemspec
+++ b/tinysky.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", "~> 2"
-  spec.add_dependency "jwt", "~> 2"
+  spec.add_dependency "jwt"
   spec.add_dependency "zeitwerk"
 end


### PR DESCRIPTION
I read through the [JWT Upgrade Guide](https://github.com/jwt/ruby-jwt/blob/main/UPGRADING.md) and nothing stood out as affecting how I use this gem so I think this is just a simple upgrade. I did run the facet example script to sanity check and that worked fine so yeah let's do it. I'll end up releasing this as 0.0.5 so that I can use it in Monolithium.